### PR TITLE
specify vpc for create_security_group

### DIFF
--- a/efsync/main.py
+++ b/efsync/main.py
@@ -7,6 +7,7 @@ from efsync.utils.security_group.ec2_security_group import create_secruity_group
 from efsync.utils.ec2.ec2_main import create_ec2_instance, terminate_ec2_instance
 from efsync.utils.iam_profile.iam_profile import delete_iam_profile
 from efsync.utils.ssh.scp_to_ec2 import copy_files_to_ec2
+from efsync.utils.ssh.vpc import get_vpc_id
 
 from efsync.utils.config.load_config import load_config
 
@@ -27,11 +28,19 @@ def efsync(input_args):
         logger.info('loading config')
         config = load_config(input_args)
         #
+        # getting vpc_id
+        #
+        logger.info('getting vpc id')
+        try:
+            config['vpc_id'] = get_vpc_id(config['bt3'], config['subnet_Id'])
+        except Exception as e:
+            raise(e)
+        #
         # creates security_group
         #
         logger.info(f"creating security group")
         try:
-            config['security_group'] = create_secruity_group(config['bt3'])
+            config['security_group'] = create_secruity_group(config['bt3'], config['vpc_id'])
         except Exception as e:
             raise(e)
         # 
@@ -39,7 +48,7 @@ def efsync(input_args):
         #
         logger.info(f"loading default security group")
         try:
-            config['default_sec_id'] = get_security_group_id(config['bt3'], 'default')
+            config['default_sec_id'] = get_security_group_id(config['bt3'], 'default', config['vpc_id'])
         except Exception as e:
             raise(e)
         

--- a/efsync/utils/security_group/ec2_security_group.py
+++ b/efsync/utils/security_group/ec2_security_group.py
@@ -1,11 +1,11 @@
 import boto3
 
 
-def create_secruity_group(bt3=None):
+def create_secruity_group(bt3=None, vpc_id=None):
     try:
         ec2 = bt3.client('ec2')
         sec_group = ec2.create_security_group(
-            GroupName='efsync-group', Description='efsync-group sec group')
+            GroupName='efsync-group', Description='efsync-group sec group', VpcId=vpc_id)
         ec2.authorize_security_group_ingress(GroupId=sec_group['GroupId'],
                                              IpProtocol="tcp",
                                              CidrIp="0.0.0.0/0",
@@ -19,12 +19,13 @@ def create_secruity_group(bt3=None):
             raise(e)
 
 
-def get_security_group_id(bt3=None, group_name='efsync-group'):
+def get_security_group_id(bt3=None, group_name='efsync-group', vpc_id=None):
     try:
         ec2 = bt3.client('ec2')
         response = ec2.describe_security_groups(
             Filters=[
-                dict(Name='group-name', Values=[group_name])
+                dict(Name='group-name', Values=[group_name]),
+                dict(Name='vpc-id', Values=[vpc_id])
             ]
         )
         group_id = response['SecurityGroups'][0]['GroupId']

--- a/efsync/utils/vpc/vpc.py
+++ b/efsync/utils/vpc/vpc.py
@@ -1,0 +1,15 @@
+import boto3
+
+def get_vpc_id(bt3=None, subnet_id):
+    try:
+        ec2 = bt3.client('ec2')
+        response = ec2.describe_subnets(
+            Filters=[{
+                'Name': 'subnet-id',
+                'Values': [subnet_id]
+            }]
+        )
+        vpc_id = response['Subnets'][0]['VpcId']
+        return vpc_id
+    except Exception as e:
+        raise(e)


### PR DESCRIPTION
Need to specify a VPC ID when an AWS account has multiple VPCs.

Otherwise, get this error
```
ClientError('An error occurred (InvalidParameter) when calling the RunInstances operation: Security group sg-XXX and subnet subnet-XXX belong to different networks.')
```