### PR TITLE
non-default vpc and get latest ami via ssm

### DIFF
--- a/efsync/main.py
+++ b/efsync/main.py
@@ -7,7 +7,7 @@ from efsync.utils.security_group.ec2_security_group import create_secruity_group
 from efsync.utils.ec2.ec2_main import create_ec2_instance, terminate_ec2_instance
 from efsync.utils.iam_profile.iam_profile import delete_iam_profile
 from efsync.utils.ssh.scp_to_ec2 import copy_files_to_ec2
-from efsync.utils.ssh.vpc import get_vpc_id
+from efsync.utils.vpc.vpc import get_vpc_id
 
 from efsync.utils.config.load_config import load_config
 

--- a/efsync/utils/security_group/ec2_security_group.py
+++ b/efsync/utils/security_group/ec2_security_group.py
@@ -34,14 +34,13 @@ def get_security_group_id(bt3=None, group_name='efsync-group', vpc_id=None):
         raise(e)
 
 
-def delete_secruity_group(bt3=None, group_id=''):
+def delete_secruity_group(bt3=None, group_id='', group_name='efsync-group'):
     try:
         ec2 = bt3.client('ec2')
         if len(group_id) > 0:
-            sec_group = ec2.delete_security_group(GroupId=group_id,
-                                                  GroupName='efsync-group')
+            sec_group = ec2.delete_security_group(GroupId=group_id)
         else:
-            sec_group = ec2.delete_security_group(GroupName='efsync-group')
+            sec_group = ec2.delete_security_group(GroupName=group_name)
         return True
     except Exception as e:
         print(repr(e))

--- a/efsync/utils/vpc/vpc.py
+++ b/efsync/utils/vpc/vpc.py
@@ -1,6 +1,6 @@
 import boto3
 
-def get_vpc_id(bt3=None, subnet_id):
+def get_vpc_id(bt3=None, subnet_id=None):
     try:
         ec2 = bt3.client('ec2')
         response = ec2.describe_subnets(


### PR DESCRIPTION
-  works with non-default VPCs
    - gets VPC id of specified subnet
- remove hardcoded AMI id
    - gets latest AMI id using SSM parameter
    - see https://aws.amazon.com/blogs/compute/query-for-the-latest-amazon-linux-ami-ids-using-aws-systems-manager-parameter-store/
